### PR TITLE
[RSpec編] 04_未完成のテストコード修正

### DIFF
--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     deadline { Random.rand(from..to) }
 
     trait 'completion_task' do
-      status { 'done' }
+      status { :done }
       completion_date { Time.current.yesterday }
     end
   end

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -1,11 +1,11 @@
 FactoryBot.define do
   factory :task do
-    association :project
     title { 'Task' }
     status { rand(2) }
     from = Date.parse("2019/08/01")
     to   = Date.parse("2019/12/31")
     deadline { Random.rand(from..to) }
+    association :project
 
     trait 'completion_task' do
       status { :done }

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -1,11 +1,11 @@
 FactoryBot.define do
   factory :task do
+    association :project
     title { 'Task' }
     status { rand(2) }
     from = Date.parse("2019/08/01")
     to   = Date.parse("2019/12/31")
     deadline { Random.rand(from..to) }
-    project_id { 1 }
 
     trait 'completion_task' do
       status { 'done' }

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -5,5 +5,11 @@ FactoryBot.define do
     from = Date.parse("2019/08/01")
     to   = Date.parse("2019/12/31")
     deadline { Random.rand(from..to) }
+    project_id { 1 }
+
+    trait 'completion_task' do
+      status { 'done' }
+      completion_date { Time.current.yesterday }
+    end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -59,4 +59,5 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
   config.include FactoryBot::Syntax::Methods
+  include ApplicationHelper
 end

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -2,10 +2,11 @@ require 'rails_helper'
 include ApplicationHelper
 
 RSpec.describe 'Task', type: :system do
+  let(:project) { create(:project) }
+  let(:task) { create(:task) }
   describe 'Task一覧' do
-    let(:project) { FactoryBot.create(:project) }
-    let(:task) { FactoryBot.create(:task) }
     context '正常系' do
+      
       it '一覧ページにアクセスした場合、Taskが表示されること' do
         # TODO: ローカル変数ではなく let を使用してください --OK
         visit project_tasks_path(project)
@@ -31,7 +32,6 @@ RSpec.describe 'Task', type: :system do
 
   describe 'Task新規作成' do
     context '正常系' do
-      let(:project) { FactoryBot.create(:project) }
       it 'Taskが新規作成されること' do
         # TODO: ローカル変数ではなく let を使用してください --OK
         visit project_tasks_path(project)
@@ -47,8 +47,6 @@ RSpec.describe 'Task', type: :system do
 
   describe 'Task詳細' do
     context '正常系' do
-      let(:project) { FactoryBot.create(:project) }
-      let(:task) { FactoryBot.create(:task) }
       it 'Taskが表示されること' do
         # TODO: ローカル変数ではなく let を使用してください
         visit project_task_path(project, task)
@@ -62,9 +60,6 @@ RSpec.describe 'Task', type: :system do
 
   describe 'Task編集' do
     context '正常系' do
-      let(:project) { FactoryBot.create(:project) }
-      let(:task) { FactoryBot.create(:task) }
-      let(:completion_task) { FactoryBot.create(:task, :completion_task) }
       it 'Taskを編集した場合、一覧画面で編集後の内容が表示されること' do
         # FIXME: テストが失敗するので修正してください -OK
         visit edit_project_task_path(project, task)
@@ -88,6 +83,7 @@ RSpec.describe 'Task', type: :system do
       
       it '既にステータスが完了のタスクのステータスを変更した場合、Taskの完了日が更新されないこと' do
         # TODO: FactoryBotのtraitを利用してください
+        completion_task = create(:task, :completion_task)
         visit edit_project_task_path(project, completion_task)
         select 'todo', from: 'Status'
         click_button 'Update Task'
@@ -102,8 +98,7 @@ RSpec.describe 'Task', type: :system do
     context '正常系' do
       # FIXME: テストが失敗するので修正してください
       it 'Taskが削除されること' do
-        project = FactoryBot.create(:project)
-        task = FactoryBot.create(:task)
+        task = create(:task)
         # プロジェクトのタスク一覧ページに遷移
         visit project_tasks_path(project)
         click_link 'Destroy'

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -46,10 +46,10 @@ RSpec.describe 'Task', type: :system do
 
   describe 'Task詳細' do
     context '正常系' do
+      let(:project) { FactoryBot.create(:project) }
+      let(:task) { FactoryBot.create(:task) }
       it 'Taskが表示されること' do
         # TODO: ローカル変数ではなく let を使用してください
-        project = FactoryBot.create(:project)
-        task = FactoryBot.create(:task, project_id: project.id)
         visit project_task_path(project, task)
         expect(page).to have_content(task.title)
         expect(page).to have_content(task.status)

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -65,11 +65,14 @@ RSpec.describe 'Task', type: :system do
         # FIXME: テストが失敗するので修正してください
         project = FactoryBot.create(:project)
         task = FactoryBot.create(:task, project_id: project.id)
+      it 'Taskを編集した場合、一覧画面で編集後の内容が表示されること' do
+        # FIXME: テストが失敗するので修正してください -OK
         visit edit_project_task_path(project, task)
         fill_in 'Deadline', with: Time.current
         click_button 'Update Task'
         click_link 'Back'
-        expect(find('.task_list')).to have_content(Time.current.strftime('%Y-%m-%d'))
+        # 日時の表示形式を変更
+        expect(find('.task_list')).to have_content(Time.current.strftime('%-m/%d %-H:%M'))
         expect(current_path).to eq project_tasks_path(project)
       end
 

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -61,10 +61,8 @@ RSpec.describe 'Task', type: :system do
 
   describe 'Task編集' do
     context '正常系' do
-      xit 'Taskを編集した場合、一覧画面で編集後の内容が表示されること' do
-        # FIXME: テストが失敗するので修正してください
-        project = FactoryBot.create(:project)
-        task = FactoryBot.create(:task, project_id: project.id)
+      let(:project) { FactoryBot.create(:project) }
+      let(:task) { FactoryBot.create(:task) }
       it 'Taskを編集した場合、一覧画面で編集後の内容が表示されること' do
         # FIXME: テストが失敗するので修正してください -OK
         visit edit_project_task_path(project, task)
@@ -78,8 +76,6 @@ RSpec.describe 'Task', type: :system do
 
       it 'ステータスを完了にした場合、Taskの完了日に今日の日付が登録されること' do
         # TODO: ローカル変数ではなく let を使用してください
-        project = FactoryBot.create(:project)
-        task = FactoryBot.create(:task, project_id: project.id)
         visit edit_project_task_path(project, task)
         select 'done', from: 'Status'
         click_button 'Update Task'

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -2,11 +2,11 @@ require 'rails_helper'
 
 RSpec.describe 'Task', type: :system do
   describe 'Task一覧' do
+    let(:project) { FactoryBot.create(:project) }
+    let(:task) { FactoryBot.create(:task) }
     context '正常系' do
       it '一覧ページにアクセスした場合、Taskが表示されること' do
-        # TODO: ローカル変数ではなく let を使用してください
-        project = FactoryBot.create(:project)
-        task = FactoryBot.create(:task, project_id: project.id)
+        # TODO: ローカル変数ではなく let を使用してください --OK
         visit project_tasks_path(project)
         expect(page).to have_content task.title
         expect(Task.count).to eq 1

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -30,9 +30,9 @@ RSpec.describe 'Task', type: :system do
 
   describe 'Task新規作成' do
     context '正常系' do
+      let(:project) { FactoryBot.create(:project) }
       it 'Taskが新規作成されること' do
-        # TODO: ローカル変数ではなく let を使用してください
-        project = FactoryBot.create(:project)
+        # TODO: ローカル変数ではなく let を使用してください --OK
         visit project_tasks_path(project)
         click_link 'New Task'
         fill_in 'Title', with: 'test'

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-include ApplicationHelper
 
 RSpec.describe 'Task', type: :system do
   let(:project) { create(:project) }

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -13,12 +13,14 @@ RSpec.describe 'Task', type: :system do
         expect(current_path).to eq project_tasks_path(project)
       end
 
-      xit 'Project詳細からTask一覧ページにアクセスした場合、Taskが表示されること' do
-        # FIXME: テストが失敗するので修正してください
-        project = FactoryBot.create(:project)
-        task = FactoryBot.create(:task, project_id: project.id)
+      it 'Project詳細からTask一覧ページにアクセスした場合、Taskが表示されること' do
+        # FIXME: テストが失敗するので修正してください --OK
+        # Project詳細ページに遷移
         visit project_path(project)
+        # プロジェクトのタスク一覧ページに遷移するリンクをクリック
         click_link 'View Todos'
+        # 別タブで開かれた先のページ(タスク一覧ページ)をテスト
+        switch_to_window(windows.last)
         expect(page).to have_content task.title
         expect(Task.count).to eq 1
         expect(current_path).to eq project_tasks_path(project)

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -100,13 +100,15 @@ RSpec.describe 'Task', type: :system do
   describe 'Task削除' do
     context '正常系' do
       # FIXME: テストが失敗するので修正してください
-      xit 'Taskが削除されること' do
+      it 'Taskが削除されること' do
         project = FactoryBot.create(:project)
-        task = FactoryBot.create(:task, project_id: project.id)
+        task = FactoryBot.create(:task)
+        # プロジェクトのタスク一覧ページに遷移
         visit project_tasks_path(project)
         click_link 'Destroy'
+        # confirmダイアログのテスト
         page.driver.browser.switch_to.alert.accept
-        expect(page).not_to have_content task.title
+        expect(page).to have_content 'Task was successfully destroyed.'
         expect(Task.count).to eq 0
         expect(current_path).to eq project_tasks_path(project)
       end

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+include ApplicationHelper
 
 RSpec.describe 'Task', type: :system do
   describe 'Task一覧' do
@@ -71,7 +72,7 @@ RSpec.describe 'Task', type: :system do
         click_button 'Update Task'
         click_link 'Back'
         # 日時の表示形式を変更
-        expect(find('.task_list')).to have_content(Time.current.strftime('%-m/%d %-H:%M'))
+        expect(find('.task_list')).to have_content(short_time(Time.current))
         expect(current_path).to eq project_tasks_path(project)
       end
 

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe 'Task', type: :system do
         click_link 'Destroy'
         # confirmダイアログのテスト
         page.driver.browser.switch_to.alert.accept
-        expect(page).to have_content 'Task was successfully destroyed.'
+        expect(find('.task_list')).not_to have_content task.title
         expect(Task.count).to eq 0
         expect(current_path).to eq project_tasks_path(project)
       end

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -63,6 +63,7 @@ RSpec.describe 'Task', type: :system do
     context '正常系' do
       let(:project) { FactoryBot.create(:project) }
       let(:task) { FactoryBot.create(:task) }
+      let(:completion_task) { FactoryBot.create(:task, :completion_task) }
       it 'Taskを編集した場合、一覧画面で編集後の内容が表示されること' do
         # FIXME: テストが失敗するので修正してください -OK
         visit edit_project_task_path(project, task)
@@ -83,17 +84,15 @@ RSpec.describe 'Task', type: :system do
         expect(page).to have_content(Time.current.strftime('%Y-%m-%d'))
         expect(current_path).to eq project_task_path(project, task)
       end
-
+      
       it '既にステータスが完了のタスクのステータスを変更した場合、Taskの完了日が更新されないこと' do
         # TODO: FactoryBotのtraitを利用してください
-        project = FactoryBot.create(:project)
-        task = FactoryBot.create(:task, project_id: project.id, status: :done, completion_date: Time.current.yesterday)
-        visit edit_project_task_path(project, task)
+        visit edit_project_task_path(project, completion_task)
         select 'todo', from: 'Status'
         click_button 'Update Task'
         expect(page).to have_content('todo')
         expect(page).not_to have_content(Time.current.strftime('%Y-%m-%d'))
-        expect(current_path).to eq project_task_path(project, task)
+        expect(current_path).to eq project_task_path(project, completion_task)
       end
     end
   end


### PR DESCRIPTION
#TODO
テストケース内で指示された箇所のローカル変数で定義されたFactoryBotのテストデータをdescribe単位でletで定義
it '既にステータスが完了のタスクのステータスを変更した場合、Taskの完了日が更新されないこと' 内のtaskのテストデータに関しては、traitを使用してstatusとcompletion_dateを含むcompletion_taskを作成

#FIXME
①テストケース it 'Project詳細からTask一覧ページにアクセスした場合、Taskが表示されること'
click_link 'View Todos'以下でproject詳細画面の検証がされ、テストが失敗する状況だったため、 'View Todos'をクリックして別タブで開かれるタスク一覧ページが検証の対象となるようにswitch_to_window(windows.last)を追記
②テストケース it 'Taskを編集した場合、一覧画面で編集後の内容が表示されること' 
編集後のタスクの日時形式がテストに引っかかっていたため、テスト側の日時の表示形式を修正
③テストケース it 'Taskが削除されること'
Destroyリンクをクリック後のページで検証する文字列を、削除成功のフラッシュメッセージに変更
